### PR TITLE
Magic Desk 16K config

### DIFF
--- a/vice/src/c64/c64cart.h
+++ b/vice/src/c64/c64cart.h
@@ -29,8 +29,8 @@
 
 #include "types.h"
 
-/* Cartridge ROM limit = 1MB (EasyFlash) */
-#define C64CART_ROM_LIMIT (1024 * 1024)
+/* Cartridge ROM limit = 2MB (Magic Desk 2 - 16K config) */
+#define C64CART_ROM_LIMIT (2 * 1024 * 1024)
 /* Cartridge RAM limit = 32kB (IDE64, ...) */
 #define C64CART_RAM_LIMIT (32 * 1024)
 /* maximum size of a full "all inclusive" cartridge image (16MB for REU) */

--- a/vice/src/c64/cart/Makefile.am
+++ b/vice/src/c64/cart/Makefile.am
@@ -137,6 +137,7 @@ libc64cart_a_SOURCES = \
 	mach5.c \
 	mach5.h \
 	magicdesk.c \
+	magicdesk16.c \
 	magicdesk.h \
 	magicformel.c \
 	magicformel.h \

--- a/vice/src/c64/cart/c64cart.c
+++ b/vice/src/c64/cart/c64cart.c
@@ -442,6 +442,7 @@ static int set_cartridge_type(int val, void *param)
         case CARTRIDGE_KCS_POWER:
         case CARTRIDGE_MACH5:
         case CARTRIDGE_MAGIC_DESK:
+        case CARTRIDGE_MAGIC_DESK_16:
         case CARTRIDGE_MAGIC_FORMEL:
         case CARTRIDGE_MAGIC_VOICE:
         case CARTRIDGE_MAX_BASIC:
@@ -867,6 +868,9 @@ static int crt_attach(const char *filename, uint8_t *rawcart)
                 break;
             case CARTRIDGE_MAGIC_DESK:
                 rc = magicdesk_crt_attach(fd, rawcart);
+                break;
+            case CARTRIDGE_MAGIC_DESK_16:
+                rc = magicdesk16_crt_attach(fd, rawcart);
                 break;
             case CARTRIDGE_MAGIC_FORMEL:
                 rc = magicformel_crt_attach(fd, rawcart);

--- a/vice/src/c64/cart/c64carthooks.c
+++ b/vice/src/c64/cart/c64carthooks.c
@@ -357,6 +357,9 @@ static const cmdline_option_t cmdline_options[] =
     { "-cartmd", CALL_FUNCTION, CMDLINE_ATTRIB_NEED_ARGS,
       cart_attach_cmdline, (void *)CARTRIDGE_MAGIC_DESK, NULL, NULL,
       "<Name>", "Attach raw 32/64/128KiB Magic Desk cartridge image" },
+    { "-cartmd16", CALL_FUNCTION, CMDLINE_ATTRIB_NEED_ARGS,
+      cart_attach_cmdline, (void *)CARTRIDGE_MAGIC_DESK_16, NULL, NULL,
+      "<Name>", "Attach raw up to 2048KiB Magic Desk 16K cartridge image" },
     { "-cartmf", CALL_FUNCTION, CMDLINE_ATTRIB_NEED_ARGS,
       cart_attach_cmdline, (void *)CARTRIDGE_MAGIC_FORMEL, NULL, NULL,
       "<Name>", "Attach raw Magic Formel cartridge image" },
@@ -994,6 +997,8 @@ int cart_bin_attach(int type, const char *filename, uint8_t *rawcart)
             return mach5_bin_attach(filename, rawcart);
         case CARTRIDGE_MAGIC_DESK:
             return magicdesk_bin_attach(filename, rawcart);
+        case CARTRIDGE_MAGIC_DESK_16:
+            return magicdesk16_bin_attach(filename, rawcart);
         case CARTRIDGE_MAGIC_FORMEL:
             return magicformel_bin_attach(filename, rawcart);
         case CARTRIDGE_MAX_BASIC:
@@ -1244,6 +1249,9 @@ void cart_attach(int type, uint8_t *rawcart)
             break;
         case CARTRIDGE_MAGIC_DESK:
             magicdesk_config_setup(rawcart);
+            break;
+        case CARTRIDGE_MAGIC_DESK_16:
+            magicdesk16_config_setup(rawcart);
             break;
         case CARTRIDGE_MAGIC_FORMEL:
             magicformel_config_setup(rawcart);
@@ -1835,6 +1843,9 @@ void cart_detach(int type)
         case CARTRIDGE_MAGIC_DESK:
             magicdesk_detach();
             break;
+        case CARTRIDGE_MAGIC_DESK_16:
+            magicdesk16_detach();
+            break;
         case CARTRIDGE_MAGIC_FORMEL:
             magicformel_detach();
             break;
@@ -2125,6 +2136,9 @@ void cartridge_init_config(void)
                 break;
             case CARTRIDGE_MAGIC_DESK:
                 magicdesk_config_init();
+                break;
+            case CARTRIDGE_MAGIC_DESK_16:
+                magicdesk16_config_init();
                 break;
             case CARTRIDGE_MAGIC_FORMEL:
                 magicformel_config_init();
@@ -3341,6 +3355,11 @@ int cartridge_snapshot_write_modules(struct snapshot_s *s)
                 break;
             case CARTRIDGE_MAGIC_DESK:
                 if (magicdesk_snapshot_write_module(s) < 0) {
+                    return -1;
+                }
+                break;
+            case CARTRIDGE_MAGIC_DESK_16:
+                if (magicdesk16_snapshot_write_module(s) < 0) {
                     return -1;
                 }
                 break;

--- a/vice/src/c64/cart/magicdesk.h
+++ b/vice/src/c64/cart/magicdesk.h
@@ -36,10 +36,17 @@ void magicdesk_config_setup(uint8_t *rawcart);
 int magicdesk_bin_attach(const char *filename, uint8_t *rawcart);
 int magicdesk_crt_attach(FILE *fd, uint8_t *rawcart);
 void magicdesk_detach(void);
+void magicdesk16_config_init(void);
+void magicdesk16_config_setup(uint8_t *rawcart);
+int magicdesk16_bin_attach(const char *filename, uint8_t *rawcart);
+int magicdesk16_crt_attach(FILE *fd, uint8_t *rawcart);
+void magicdesk16_detach(void);
 
 struct snapshot_s;
 
 int magicdesk_snapshot_write_module(struct snapshot_s *s);
 int magicdesk_snapshot_read_module(struct snapshot_s *s);
+int magicdesk16_snapshot_write_module(struct snapshot_s *s);
+int magicdesk16_snapshot_read_module(struct snapshot_s *s);
 
 #endif

--- a/vice/src/c64/cart/magicdesk16.c
+++ b/vice/src/c64/cart/magicdesk16.c
@@ -1,0 +1,311 @@
+/*
+ * magicdesk16.c - Cartridge handling, Magic Desk 16K cart.
+ *
+ * Original magicdesk.c Written by
+ *  Marco van den Heuvel <blackystardust68@yahoo.com>
+ 
+ * 16K Mod Written by
+ *  Salvo Cristaldi <crystal@unict.it>
+ *
+ * This file is part of VICE, the Versatile Commodore Emulator.
+ * See README for copyright notice.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ *  02111-1307  USA.
+ *
+ */
+
+#define MAGICDESK_DEBUG
+
+#include "vice.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define CARTRIDGE_INCLUDE_SLOTMAIN_API
+#include "c64cartsystem.h"
+#undef CARTRIDGE_INCLUDE_SLOTMAIN_API
+#include "c64mem.h"
+#include "cartio.h"
+#include "cartridge.h"
+#include "export.h"
+#include "magicdesk.h"
+#include "monitor.h"
+#include "snapshot.h"
+#include "types.h"
+#include "util.h"
+#include "crt.h"
+
+#ifdef MAGICDESK_DEBUG
+#define DBG(x) printf x
+#else
+#define DBG(x)
+#endif
+
+/*
+    "Magic Desk 16K" Cartridge
+
+    - supports all "Magic Desk Clone" homebrew cart with 16k game config, up to 2 MB
+
+    - ROM is always mapped in at $8000-$BFFF (16k game).
+
+    - 1 register at io1 / de00:
+
+    bit 0-6   bank number
+    bit 7     exrom (1 = cart disabled)
+*/
+
+#define MAXBANKS 128
+
+static uint8_t regval = 0;
+static uint8_t bankmask = 0x7f;
+
+static void magicdesk16_io1_store(uint16_t addr, uint8_t value)
+{
+    regval = value & (0x80 | bankmask);
+    cart_romhbank_set_slotmain(value & bankmask);
+	cart_romlbank_set_slotmain(value & bankmask);
+    cart_set_port_game_slotmain(0);
+    if (value & 0x80) {
+        /* turn off cart ROM */
+        cart_set_port_exrom_slotmain(0);
+		cart_set_port_game_slotmain(0);
+    } else {
+        cart_set_port_exrom_slotmain(1);
+		cart_set_port_game_slotmain(1);
+    }
+    cart_port_config_changed_slotmain();
+    DBG(("MAGICDESK16: Reg: %02x (Bank: %d of %d, %s)\n", regval, (regval & bankmask), bankmask + 1, (regval & 0x80) ? "disabled" : "enabled"));
+}
+
+static uint8_t magicdesk16_io1_peek(uint16_t addr)
+{
+    return regval;
+}
+
+static int magicdesk16_dump(void)
+{
+    mon_out("Reg: %02x (Bank: %d of %d, %s)\n", regval, (regval & bankmask), bankmask + 1, (regval & 0x80) ? "disabled" : "enabled");
+    return 0;
+}
+
+
+/* ---------------------------------------------------------------------*/
+
+static io_source_t magicdesk16_device = {
+    CARTRIDGE_NAME_MAGIC_DESK_16, /* name of the device */
+    IO_DETACH_CART,            /* use cartridge ID to detach the device when involved in a read-collision */
+    IO_DETACH_NO_RESOURCE,     /* does not use a resource for detach */
+    0xde00, 0xdeff, 0xff,      /* range for the device, address is ignored, reg:$de00, mirrors:$de01-$deff */
+    0,                         /* read is never valid, reg is write only */
+    magicdesk16_io1_store,       /* store function */
+    NULL,                      /* NO poke function */
+    NULL,                      /* read function */
+    magicdesk16_io1_peek,        /* peek function */
+    magicdesk16_dump,            /* device state information dump function */
+    CARTRIDGE_MAGIC_DESK_16,      /* cartridge ID */
+    IO_PRIO_NORMAL,            /* normal priority, device read needs to be checked for collisions */
+    0                          /* insertion order, gets filled in by the registration function */
+};
+
+static io_source_list_t *magicdesk16_list_item = NULL;
+
+static const export_resource_t export_res = {
+    CARTRIDGE_NAME_MAGIC_DESK_16, 1, 1, &magicdesk16_device, NULL, CARTRIDGE_MAGIC_DESK_16
+};
+
+/* ---------------------------------------------------------------------*/
+
+void magicdesk16_config_init(void)
+{
+    //cart_config_changed_slotmain(CMODE_16KGAME, CMODE_16KGAME, CMODE_READ);
+    magicdesk16_io1_store((uint16_t)0xde00, 0);
+}
+
+void magicdesk16_config_setup(uint8_t *rawcart)
+{
+    //printf("magicdesk16_config_setup - MAXBANKS: %d\n", MAXBANKS);
+	//cart_config_changed_slotmain(CMODE_16KGAME, CMODE_16KGAME, CMODE_READ);
+	for (int i=0; i< MAXBANKS; i++) {
+		//memcpy(&roml_banks[0x0000+i*0x2000], &rawcart[0x0000+i*0x4000], 0x2000);
+		//memcpy(&romh_banks[0x0000+i*0x2000], &rawcart[0x2000+i*0x4000], 0x2000);
+		memcpy(&roml_banks[i*0x2000], &rawcart[i*0x4000], 0x2000);
+		memcpy(&romh_banks[i*0x2000], &rawcart[0x2000 + i*0x4000], 0x2000);
+		//memcpy(&romh_banks[i*0x2000], &rawcart[(i+MAXBANKS/2)*0x2000], 0x2000);
+	}
+
+	//printf("rawcart %02x %02x %02x %02x %02x %02x\n",  
+	//rawcart[(255)*0x2000], rawcart[(255)*0x2000+1],rawcart[(255)*0x2000+2],rawcart[(255)*0x2000+3],rawcart[(255)*0x2000+4], rawcart[(255)*0x2000+5]);
+	//cart_config_changed_slotmain(CMODE_16KGAME, CMODE_16KGAME, CMODE_READ);
+	//cart_config_changed_slotmain(CMODE_8KGAME, CMODE_8KGAME, CMODE_READ);
+}
+
+/* ---------------------------------------------------------------------*/
+
+static int magicdesk16_common_attach(void)
+{
+    if (export_add(&export_res) < 0) {
+        return -1;
+    }
+    magicdesk16_list_item = io_source_register(&magicdesk16_device);
+    return 0;
+}
+
+int magicdesk16_bin_attach(const char *filename, uint8_t *rawcart)
+{
+    bankmask = 0x7f;
+    if (util_file_load(filename, rawcart, 0x200000, UTIL_FILE_LOAD_SKIP_ADDRESS) < 0) {
+        bankmask = 0x3f;
+        if (util_file_load(filename, rawcart, 0x100000, UTIL_FILE_LOAD_SKIP_ADDRESS) < 0) {
+            bankmask = 0x1f;
+            if (util_file_load(filename, rawcart, 0x80000, UTIL_FILE_LOAD_SKIP_ADDRESS) < 0) {
+                bankmask = 0x0f;
+                if (util_file_load(filename, rawcart, 0x40000, UTIL_FILE_LOAD_SKIP_ADDRESS) < 0) {
+                    bankmask = 0x07;
+                    if (util_file_load(filename, rawcart, 0x20000, UTIL_FILE_LOAD_SKIP_ADDRESS) < 0) {
+                        bankmask = 0x03;
+                        if (util_file_load(filename, rawcart, 0x10000, UTIL_FILE_LOAD_SKIP_ADDRESS) < 0) {
+                            bankmask = 0x01;
+							if (util_file_load(filename, rawcart, 0x8000, UTIL_FILE_LOAD_SKIP_ADDRESS) < 0) {
+								return -1;
+							}
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return magicdesk16_common_attach();
+}
+
+int magicdesk16_crt_attach(FILE *fd, uint8_t *rawcart)
+{
+    crt_chip_header_t chip;
+    int lastbank = 0;
+	//printf("crt_read_chip ....\n");
+		
+    while (1) {
+        if (crt_read_chip_header(&chip, fd)) {
+            break;
+        }
+        //printf("chip.bank %u - chip.start 0x%x - chip size: %d - chip.bank << 13: 0x%x\n", chip.bank,chip.start, chip.size, chip.bank << 14);
+		if ((chip.bank >= MAXBANKS) || ((chip.start != 0x8000) && (chip.start != 0xa000)) || (chip.size != 0x4000)) {
+            return -1;
+        }
+        if (crt_read_chip(rawcart, chip.bank << 14, &chip, fd)) {
+            return -1;
+        }
+        if (chip.bank > lastbank) {
+            lastbank = chip.bank;
+        }
+    }
+    //printf("crt_read_chip OK - lastbank: %d \n", lastbank);
+	if (lastbank >= MAXBANKS) {
+        /* more than 128 banks does not work */
+        return -1;
+    } else if (lastbank >= 64) {
+        /* min 65, max 128 banks */
+        bankmask = 0x7f;
+    } else if (lastbank >= 32) {
+        /* min 33, max 64 banks */
+        bankmask = 0x3f;
+    } else if (lastbank >= 16) {
+        /* min 17, max 32 banks */
+        bankmask = 0x1f;
+    } else if (lastbank >= 8) {
+        /* min 9, max 16 banks */
+        bankmask = 0x0f;
+    } else if (lastbank >= 4) {
+        /* min 5, max 8 banks */
+        bankmask = 0x07;
+    } else if (lastbank >= 2) {
+        /* min 3, max 4 banks */
+        bankmask = 0x03;
+	} else {
+		/* max 2 banks */
+		bankmask = 0x01;
+    }
+	
+    return magicdesk16_common_attach();
+}
+
+void magicdesk16_detach(void)
+{
+    export_remove(&export_res);
+    io_source_unregister(magicdesk16_list_item);
+    magicdesk16_list_item = NULL;
+}
+
+/* ---------------------------------------------------------------------*/
+
+#define CART_DUMP_VER_MAJOR   0
+#define CART_DUMP_VER_MINOR   2
+#define SNAP_MODULE_NAME  "CARTMD16"
+
+int magicdesk16_snapshot_write_module(snapshot_t *s)
+{
+    snapshot_module_t *m;
+
+    m = snapshot_module_create(s, SNAP_MODULE_NAME,
+                               CART_DUMP_VER_MAJOR, CART_DUMP_VER_MINOR);
+    if (m == NULL) {
+        return -1;
+    }
+
+    if (0
+        || (SMW_B(m, (uint8_t)regval) < 0)
+        || (SMW_B(m, (uint8_t)bankmask) < 0)
+        || (SMW_BA(m, roml_banks, 0x2000 * MAXBANKS) < 0)
+		|| (SMW_BA(m, romh_banks, 0x2000 * MAXBANKS) < 0)) {
+        snapshot_module_close(m);
+        return -1;
+    }
+
+    snapshot_module_close(m);
+    return 0;
+}
+
+int magicdesk16_snapshot_read_module(snapshot_t *s)
+{
+    uint8_t vmajor, vminor;
+    snapshot_module_t *m;
+
+    m = snapshot_module_open(s, SNAP_MODULE_NAME, &vmajor, &vminor);
+    if (m == NULL) {
+        return -1;
+    }
+
+    if ((vmajor != CART_DUMP_VER_MAJOR) || (vminor != CART_DUMP_VER_MINOR)) {
+        snapshot_module_close(m);
+        return -1;
+    }
+
+    if (0
+        || (SMR_B(m, &regval) < 0)
+        || (SMR_B(m, &bankmask) < 0)
+        || (SMR_BA(m, roml_banks, 0x2000 * MAXBANKS) < 0)
+		|| (SMR_BA(m, romh_banks, 0x2000 * MAXBANKS) < 0)) {
+        snapshot_module_close(m);
+        return -1;
+    }
+
+    snapshot_module_close(m);
+
+    if (magicdesk16_common_attach() == -1) {
+        return -1;
+    }
+    magicdesk16_io1_store(0xde00, regval);
+    return 0;
+}

--- a/vice/src/cartridge.h
+++ b/vice/src/cartridge.h
@@ -253,7 +253,8 @@ void cartridge_sound_chip_init(void);
 #define CARTRIDGE_TURTLE_GRAPHICS_II   76 /* turtlegraphics.c */
 #define CARTRIDGE_FREEZE_FRAME_MK2     77 /* freezeframe2.c */
 #define CARTRIDGE_PARTNER64            78 /* partner64.c */
-#define CARTRIDGE_LAST                 78 /* cartconv: last cartridge in list */
+#define CARTRIDGE_MAGIC_DESK_16        79 /* magicdesk.c */
+#define CARTRIDGE_LAST                 79 /* cartconv: last cartridge in list */
 
 /* list of canonical names for the c64 cartridges:
    note: often it is hard to determine "the" official name, let alone the way it
@@ -324,6 +325,7 @@ void cartridge_sound_chip_init(void);
 #define CARTRIDGE_NAME_LT_KERNAL          "Lt. Kernal Host Adaptor"
 #define CARTRIDGE_NAME_MACH5              "MACH 5" /* http://rr.pokefinder.org/wiki/MACH_5 */
 #define CARTRIDGE_NAME_MAGIC_DESK         "Magic Desk" /* also: "Domark, Hes Australia" */
+#define CARTRIDGE_NAME_MAGIC_DESK_16      "Magic Desk 16K" /* https://github.com/crystalct/MagicDesk2 */
 #define CARTRIDGE_NAME_MAGIC_FORMEL       "Magic Formel" /* http://rr.pokefinder.org/wiki/Magic_Formel */
 #define CARTRIDGE_NAME_MAGIC_VOICE        "Magic Voice" /* all lowercase on cart ? */
 #define CARTRIDGE_NAME_MIDI_MAPLIN        "Maplin MIDI"
@@ -370,7 +372,6 @@ void cartridge_sound_chip_init(void);
 #define CARTRIDGE_NAME_WESTERMANN         "Westermann Learning"
 #define CARTRIDGE_NAME_ZAXXON             "Zaxxon"
 #define CARTRIDGE_NAME_ZIPPCODE48         "ZIPP-CODE 48"
-
 #define CARTRIDGE_NAME_GENERIC_8KB        "generic 8KiB game"
 #define CARTRIDGE_NAME_GENERIC_16KB       "generic 16KiB game"
 #define CARTRIDGE_NAME_ULTIMAX            "generic Ultimax"

--- a/vice/src/tools/cartconv/c64-cartridges.c
+++ b/vice/src/tools/cartconv/c64-cartridges.c
@@ -140,6 +140,12 @@ const cart_t cart_info[] = {
     {0, 1, CARTRIDGE_SIZE_16KB,    0x2000, 0x8000,   2, 0, CARTRIDGE_NAME_TURTLE_GRAPHICS_II,"turtle", save_regular_crt},
     {0, 1, CARTRIDGE_SIZE_16KB,    0x4000, 0x8000,   1, 0, CARTRIDGE_NAME_FREEZE_FRAME_MK2,     "ff2", save_regular_crt},
     {1, 0, CARTRIDGE_SIZE_16KB,    0x2000, 0x8000,   2, 0, CARTRIDGE_NAME_PARTNER64,      "partner64", save_stardos_crt},
-    {0, 0, 0, 0, 0, 0, 0, NULL, NULL, NULL}
+    {0, 0, CARTRIDGE_SIZE_32KB |
+           CARTRIDGE_SIZE_64KB |
+           CARTRIDGE_SIZE_128KB |
+           CARTRIDGE_SIZE_256KB |
+           CARTRIDGE_SIZE_512KB |
+           CARTRIDGE_SIZE_1024KB |
+           CARTRIDGE_SIZE_2048KB,  0x4000, 0x8000,   0, 0, CARTRIDGE_NAME_MAGIC_DESK_16,        "md16", save_regular_crt},    {0, 0, 0, 0, 0, 0, 0, NULL, NULL, NULL}
 };
 


### PR DESCRIPTION
Speaking with the developer of SNK vs Capcon (for C64), he told me that by now the limit of easy flash cartridges (1 MByte) is now tight for him and wanting to stay on a 16K configuration, GMod3 would force him to overturn his paging methods of the ROM.
From this discussion I got the idea of ​​developing an evolution of the Magic Desk: Magic Desk 2 (https://github.com/crystalct/MagicDesk2)
3 Different configuratios:
- Magic Desk 16Kbyte config
- Double Magic Desk 1MB
- GMod3 2MB Read Only cartridge

I modified sources to add the new cartridge type (Magic Desk 16Kbyte config), due to the fact that the VICE sources are well structured and very clear, the modification (addition) was very simple. I hope you will consider my PR.
